### PR TITLE
Force sensor state updates for battery operation

### DIFF
--- a/Save Point 10_04_25.yaml
+++ b/Save Point 10_04_25.yaml
@@ -85,9 +85,11 @@ sensor:
     temperature:
       name: "SHT31 Temperature"
       id: sht31_temperature
+      force_update: true
     humidity:
       name: "SHT31 Humidity"
       id: sht31_humidity
+      force_update: true
 
   - platform: adc
     id: adc_5v_raw
@@ -131,6 +133,7 @@ sensor:
     device_class: voltage
     state_class: measurement
     accuracy_decimals: 2
+    force_update: true
     filters:
       - multiply: 1.36
 
@@ -142,6 +145,7 @@ sensor:
     device_class: battery
     state_class: measurement
     accuracy_decimals: 0
+    force_update: true
     filters:
       - calibrate_linear:
           - 4.18 -> 100


### PR DESCRIPTION
## Summary
- enable `force_update` on the SHT31 temperature and humidity sensors so that each wake cycle publishes a fresh state even if the reading is unchanged
- force updates on the derived battery voltage and percentage sensors to guarantee Home Assistant receives an event before the node re-enters deep sleep

## Testing
- not run (configuration change only)


------
https://chatgpt.com/codex/tasks/task_b_68e2a33b7b608328bac040b59fa7ebad