### PR TITLE
Power sensor rail immediately before five second I2C delay

### DIFF
--- a/NewSensor.yaml
+++ b/NewSensor.yaml
@@ -20,17 +20,23 @@ esphome:
   name: planter
   friendly_name: Planter
   on_boot:
-    priority: 800
-    then:
-      - deep_sleep.prevent: deep_sleep_ctrl
-      # Sample the 5V rail immediately so voltage telemetry remains available
-      # even though the device now always follows the low-power workflow.
-      - component.update: adc_5v_raw
-      - logger.log: "Running unified low-power workflow."
-      # The deep-sleep timer is already paused; hand off to the battery boot
-      # script so it can connect, publish, and then re-enable sleep once the
-      # data has landed in Home Assistant.
-      - script.execute: handle_battery_boot
+    - priority: -300
+      then:
+        - output.turn_on: sensor_power
+    - priority: -250
+      then:
+        - delay: 5s
+    - priority: 800
+      then:
+        - deep_sleep.prevent: deep_sleep_ctrl
+        # Sample the 5V rail immediately so voltage telemetry remains available
+        # even though the device now always follows the low-power workflow.
+        - component.update: adc_5v_raw
+        - logger.log: "Running unified low-power workflow."
+        # The deep-sleep timer is already paused; hand off to the battery boot
+        # script so it can connect, publish, and then re-enable sleep once the
+        # data has landed in Home Assistant.
+        - script.execute: handle_battery_boot
 
 
 
@@ -80,10 +86,17 @@ captive_portal:
 
 # I2C bus that hosts the SHT31 sensor.
 i2c:
-  sda: 21
-  scl: 22
+  sda: GPIO21
+  scl: GPIO22
+  setup_priority: -100
   scan: false
   id: bus_a
+
+output:
+  - platform: gpio
+    pin: GPIO17
+    id: sensor_power
+    inverted: false
 
 sensor:
   # SHT31 temperature and humidity readings. Automatic polling is disabled so
@@ -92,6 +105,7 @@ sensor:
     id: sht31_sensor
     address: 0x44
     update_interval: never
+    setup_priority: -50
     temperature:
       name: "Planter Temperature"
       id: sht31_temperature
@@ -105,6 +119,7 @@ sensor:
     id: box_sht31_sensor
     address: 0x45
     update_interval: never
+    setup_priority: -50
     temperature:
       name: "Box Temperature"
       id: box_temperature
@@ -152,6 +167,30 @@ sensor:
     update_interval: never
     accuracy_decimals: 3
     internal: true
+
+  - platform: adc
+    id: soil_moisture_raw
+    pin: GPIO34
+    name: "Soil Moisture Raw"
+    attenuation: 11db
+    update_interval: never
+    accuracy_decimals: 3
+    internal: true
+
+  - platform: copy
+    source_id: soil_moisture_raw
+    name: "Capacitive Soil Moisture"
+    id: soil_moisture_percent
+    unit_of_measurement: "%"
+    device_class: moisture
+    state_class: measurement
+    accuracy_decimals: 0
+    filters:
+      - lambda: |-
+          float percent = (x / 3.0f) * 100.0f;
+          if (percent < 0.0f) percent = 0.0f;
+          if (percent > 100.0f) percent = 100.0f;
+          return percent;
 
   - platform: copy
     source_id: adc_batt_raw
@@ -277,6 +316,7 @@ script:
       - component.update: wifi_signal_dbm
       - component.update: adc_batt_raw
       - component.update: adc_5v_raw
+      - component.update: soil_moisture_raw
       - wait_until:
           condition:
             lambda: |-


### PR DESCRIPTION
## Summary
- energize the sensor rail as soon as the ESP wakes so peripherals have power during boot
- keep a five-second pause before allowing the I²C bus and sensors to initialize

## Testing
- Not run (configuration change)


------
https://chatgpt.com/codex/tasks/task_b_68fd0c7fe4108328937b22e8c7e9770e