### PR TITLE
Ensure SHT31 sensors wait for stable power

### DIFF
--- a/NewSensor.yaml
+++ b/NewSensor.yaml
@@ -20,12 +20,6 @@ esphome:
   name: planter
   friendly_name: Planter
   on_boot:
-    - priority: -300
-      then:
-        - output.turn_on: sensor_power
-    - priority: -250
-      then:
-        - delay: 5s
     - priority: 800
       then:
         - deep_sleep.prevent: deep_sleep_ctrl
@@ -88,15 +82,14 @@ captive_portal:
 i2c:
   sda: GPIO21
   scl: GPIO22
-  setup_priority: -100
-  scan: false
   id: bus_a
+  scan: true
 
-output:
-  - platform: gpio
+power_supply:
+  - id: sensor_vdd
     pin: GPIO17
-    id: sensor_power
-    inverted: false
+    enable_time: 10s
+    keep_on: true
 
 sensor:
   # SHT31 temperature and humidity readings. Automatic polling is disabled so
@@ -104,8 +97,8 @@ sensor:
   - platform: sht3xd
     id: sht31_sensor
     address: 0x44
+    power_supply: sensor_vdd
     update_interval: never
-    setup_priority: -50
     temperature:
       name: "Planter Temperature"
       id: sht31_temperature
@@ -118,8 +111,8 @@ sensor:
   - platform: sht3xd
     id: box_sht31_sensor
     address: 0x45
+    power_supply: sensor_vdd
     update_interval: never
-    setup_priority: -50
     temperature:
       name: "Box Temperature"
       id: box_temperature


### PR DESCRIPTION
## Summary
- remove the manual GPIO toggle from the boot sequence
- replace the raw GPIO output with a power_supply controller for the SHT31 rail
- attach the shared power rail to both SHT31 sensors and simplify the I²C bus definition

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68fd1e3de3b88328b8184fba39e05ec5